### PR TITLE
add settingtypes.txt

### DIFF
--- a/mods/tnt/settingtypes.txt
+++ b/mods/tnt/settingtypes.txt
@@ -1,0 +1,3 @@
+#    Enables registering tnt nodes and their craft recipe.
+#    Registering lit tnt nodes is not affected by this setting.
+enable_tnt (Enable TNT) bool nil


### PR DESCRIPTION
lt should make enable_tnt appear in the minetest settings tab, but somehow it doesn't work.